### PR TITLE
1.1

### DIFF
--- a/Get-PowerBIAuditLog.ps1
+++ b/Get-PowerBIAuditLog.ps1
@@ -1,7 +1,7 @@
 
 <#PSScriptInfo
 
-.VERSION 1.0
+.VERSION 1.1
 
 .GUID 387f77e0-7781-42a2-8d0b-005580ae6cc4
 
@@ -42,13 +42,17 @@
 #>
 [CmdletBinding()]
 param (
-    [Parameter(Mandatory, Position = 0)]
+    [Parameter(Mandatory)]
     $StartDate,
 
-    [Parameter(Mandatory, Position = 1)]
+    [Parameter(Mandatory)]
     $EndDate,
 
-    [Parameter(Position = 2)]
+    [Parameter()]
+    [int]
+    $SplitTimeIntoChunksOf = 1,
+
+    [Parameter()]
     [int]
     $PageSize = 5000,
 
@@ -61,10 +65,61 @@ param (
     $MaxRetryCount = 3
 )
 
-## Define the session ID and record type to use with the Search-UnifiedAuditLog cmdlet.
-$sessionID = (New-Guid).GUID
-$recordType = 'PowerBIAudit'
+## Function to Split the search period
+Function Split-Time {
+    [cmdletbinding()]
+    param (
+        [Parameter(Mandatory)]
+        [datetime]
+        $BottomDate,
 
+        [Parameter(Mandatory)]
+        [datetime]
+        $CeilingDate,
+
+        [Parameter()]
+        [int]
+        $Chunks
+    )
+
+    # Calculate duration between start and end dates
+    $totalDuration = New-TimeSpan -Start $BottomDate -End $CeilingDate
+
+    # Calculate interval for each chunk
+    $interval = $totalDuration.TotalHours / $Chunks
+
+    # Initialize an array to store chunk start and end times
+    $chunksArray = @()
+
+    # Start time of the first chunk
+    $chunkStartTime = $BottomDate
+
+    # Loop through to generate chunk start and end times
+    for ($i = 1; $i -le $Chunks; $i++) {
+        # End time of the current chunk
+        $chunkEndTime = $chunkStartTime.AddHours($interval)
+
+        # If it's the last chunk, adjust the end time to be the end date
+        if ($i -eq $Chunks) {
+            $chunkEndTime = $CeilingDate
+        }
+
+        # Add chunk start and end times to the array
+        $chunksArray += [PSCustomObject]@{
+            StartDate = $chunkStartTime
+            EndDate   = $chunkEndTime
+        }
+
+        # Update start time for next chunk to be one second more than the previous end time
+        $chunkStartTime = $chunkEndTime.AddSeconds(1)
+    }
+
+    # Output the array of chunk start and end times
+    return $chunksArray
+}
+
+## Define the session ID and record type to use with the Search-UnifiedAuditLog cmdlet.
+$recordType = 'PowerBIAudit'
 $retryCount = 0
 # $maxRetryCount = 3
 
@@ -81,126 +136,132 @@ try {
     $null = (Get-OrganizationConfig -ErrorAction STOP).DisplayName
 }
 catch [System.Management.Automation.CommandNotFoundException] {
-    "It looks like you forgot to connect to Remote Exchange PowerShell. You should do that first before asking me to do stuff for you." | Out-Default
-
+    "It looks like you forgot to connect to Remote Exchange PowerShell. You should do that first before asking me to do stuff for you." | Write-Verbose
     Return $null
 }
 catch {
-    "Something is wrong. You can see the error below. You should fix it before asking me to try again." | Out-Default
-    $_.Exception.Message | Out-Default
+    "Something is wrong. You can see the error below. You should fix it before asking me to try again." | Write-Verbose
+    $_.Exception.Message | Write-Verbose
 
     Return $null
 }
 #EndRegion
 
-#Region ExtractPBILogs
-Function ExtractPBILogs {
-    Search-UnifiedAuditLog -SessionId $sessionID -SessionCommand ReturnLargeSet -StartDate $startDate -EndDate $endDate -Formatted -RecordType $recordType -ResultSize $PageSize
+$searchPeriod = Split-Time -BottomDate $StartDate -CeilingDate $EndDate -Chunks $SplitTimeIntoChunksOf
+"The search period will be split into these time chunks." | Write-Verbose
+foreach ($period in $searchPeriod) {
+    $period | Select-Object StartDate, EndDate | Write-Verbose
 }
 
-#EndRegion
+$searchCounter = 0
+foreach ($period in $SearchPeriod) {
+    $sessionID = (New-Guid).GUID
+    $searchCounter++
+    "Search # $($searchCounter) of $($searchPeriod.Count)" | Write-Verbose
+    "Start Date: $($period.StartDate)" | Write-Verbose
+    "End Date: $($period.EndDate)" | Write-Verbose
+    "Session Id: $($sessionId)" | Write-Verbose
 
-"Start Date: $($StartDate)" | Out-Default
-"End Date: $($EndDate)" | Out-Default
-
-if ([datetime]($StartDate) -eq [datetime]$EndDate) {
-    "The StartDate and EndDate cannot be the same values." | Out-Default
-
-    return $null
-}
-
-if ([datetime]($EndDate) -le [datetime]($StartDate)) {
-    "The EndDate value cannot be older than the StartDate value." | Out-Default
-
-    return $null
-}
-
-Function IsResultProblematic {
-    param (
-        [Parameter(Mandatory)]
-        [ValidateNotNullOrEmpty()]
-        $inputObject
-    )
-    if ($inputObject[-1].ResultIndex -eq -1 -and $inputObject[-1].ResultCount -eq 0) {
-        return $true
-    }
-    else {
-        return $false
-    }
-}
-
-#Region Initial Records
-
-## This code region retrieves the initial records based on the specified page size.
-if ($ShowProgress) {
-    Write-Progress -Activity "Getting Power BI Audit Log [$($StartDate) - $($EndDate)]..." -Status "Progress: Getting the initial $($pageSize) records based on the page size (0%)" -PercentComplete 0 -ErrorAction SilentlyContinue
-}
-
-"Progress: Getting the initial $($pageSize) records based on the page size (0%)" | Out-Default
-do {
-    $currentPageResult = @(ExtractPBILogs)
-
-    if ($currentPageResult.Count -lt 1) {
-        "No results found" | Out-Default
+    if ([datetime]($period.StartDate) -eq [datetime]$period.EndDate) {
+        "The StartDate and EndDate cannot be the same values." | Write-Verbose
         return $null
     }
 
-    ## In some instances, the ResultIndex and ResultCount returned shows -1 and 0 respectively.
-    ## When this happens, the output will not be accurate, so the script will retry the retrieval 2 more times.
-    if ($retryCount -gt $maxRetryCount) {
-        "The result's total count and indexes are problematic after $($maxRetryCount) retries. This may be a temporary error. Try again after a few minutes." | Out-Default
+    if ([datetime]($EndDate) -le [datetime]($period.StartDate)) {
+        "The EndDate value cannot be older than the StartDate value." | Write-Verbose
         return $null
     }
 
-    if (($isProblematic = IsResultProblematic -inputObject $currentPageResult) -and ($retryCount -le $maxRetryCount)) {
-        $retryCount++
-        $sessionID = (New-Guid).Guid
-        "Retry # $($retryCount)" | Out-Default
-    }
-}
-while ($isProblematic)
-
-## Initialize the maximum results available variable once.
-$maxResultCount = $($currentPageResult[-1].ResultCount)
-"Total entries: $($maxResultCount)" | Out-Default
-
-## Set the current page result count.
-$currentPageResultCount = $($currentPageResult[-1].ResultIndex)
-## Compute the completion percentage
-$percentComplete = ($currentPageResultCount * 100) / $maxResultCount
-## Display the progress
-if ($ShowProgress) {
-    Write-Progress -Activity "Getting Power BI Audit Log [$($StartDate) - $($EndDate)]..." -Status "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" -PercentComplete $percentComplete -ErrorAction SilentlyContinue
-}
-"Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" | Out-Default
-## Display the current page results
-$currentPageResult #| Select-Object CreationDate, UserIds, Operations, AuditData, ResultIndex
-
-#EndRegion Initial 100 Records
-
-## Retrieve the rest of the audit log entries
-do {
-    $currentPageResult = @(ExtractPBILogs)
-    if ($currentPageResult) {
-        ## Set the current page result count.
-        $currentPageResultCount = $($currentPageResult[-1].ResultIndex)
-        ## Compute the completion percentage
-        $percentComplete = ($currentPageResultCount * 100) / $maxResultCount
-        ## Display the progress
-        if ($ShowProgress) {
-            Write-Progress -Activity "Getting Power BI Audit Log [$($StartDate) - $($EndDate)]..." -Status "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" -PercentComplete $percentComplete -ErrorAction SilentlyContinue
+    Function IsResultProblematic {
+        param (
+            [Parameter(Mandatory)]
+            [ValidateNotNullOrEmpty()]
+            $inputObject
+        )
+        if ($inputObject[-1].ResultIndex -eq -1 -and $inputObject[-1].ResultCount -eq 0) {
+            return $true
         }
-        "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" | Out-Default
-        ## Display the current page results
-        $currentPageResult #| Select-Object CreationDate, UserIds, Operations, AuditData, ResultIndex
+        else {
+            return $false
+        }
+    }
+
+    #Region Initial Records
+
+    ## This code region retrieves the initial records based on the specified page size.
+    if ($ShowProgress) {
+        Write-Progress -Activity "Getting Power BI Audit Log [$($period.StartDate) - $($EndDate)]..." -Status "Progress: Getting the initial $($pageSize) records based on the page size (0%)" -PercentComplete 0 -ErrorAction SilentlyContinue
+    }
+
+    "Progress: Getting the initial $($pageSize) records based on the page size (0%)" | Write-Verbose
+    do {
+        $currentPageResult = @(Search-UnifiedAuditLog -SessionId $sessionID -SessionCommand ReturnLargeSet -StartDate $period.StartDate -EndDate $period.EndDate -Formatted -RecordType $recordType -ResultSize $PageSize)
+
+        if ($currentPageResult.Count -lt 1) {
+            "No results found" | Write-Verbose
+            return $null
+        }
+
+        ## In some instances, the ResultIndex and ResultCount returned shows -1 and 0 respectively.
+        ## When this happens, the output will not be accurate, so the script will retry the retrieval N more times based on the -MaxRetryCount parameter value.
+        if ($retryCount -gt $maxRetryCount) {
+            "The result's total count and indexes are problematic after $($maxRetryCount) retries. This may be a temporary error. Try again after a few minutes." | Write-Verbose
+            return $null
+        }
+
+        if (($isProblematic = IsResultProblematic -inputObject $currentPageResult) -and ($retryCount -le $maxRetryCount)) {
+            $retryCount++
+            $sessionID = (New-Guid).Guid
+            "Retry # $($retryCount)" | Write-Verbose
+        }
+    }
+    while ($isProblematic)
+
+    ## Initialize the maximum results available variable once.
+    $maxResultCount = $($currentPageResult[-1].ResultCount)
+    "Total entries: $($maxResultCount)" | Write-Verbose
+
+    ## Set the current page result count.
+    $currentPageResultCount = $($currentPageResult[-1].ResultIndex)
+    ## Compute the completion percentage
+    $percentComplete = ($currentPageResultCount * 100) / $maxResultCount
+    ## Display the progress
+    if ($ShowProgress) {
+        Write-Progress -Activity "Getting Power BI Audit Log [$($period.StartDate) - $($EndDate)]..." -Status "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" -PercentComplete $percentComplete -ErrorAction SilentlyContinue
+    }
+    "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" | Write-Verbose
+    ## Display the current page results
+    $currentPageResult | Add-Member -MemberType NoteProperty -Name SessionId -Value $sessionID
+    $currentPageResult #| Select-Object CreationDate, UserIds, Operations, AuditData, ResultIndex
+
+    #EndRegion Initial 100 Records
+
+    ## Retrieve the rest of the audit log entries
+    do {
+        $currentPageResult = @(Search-UnifiedAuditLog -SessionId $sessionID -SessionCommand ReturnLargeSet -StartDate $period.StartDate -EndDate $period.EndDate -Formatted -RecordType $recordType -ResultSize $PageSize)
+        if ($currentPageResult) {
+            ## Set the current page result count.
+            $currentPageResultCount = $($currentPageResult[-1].ResultIndex)
+            ## Compute the completion percentage
+            $percentComplete = ($currentPageResultCount * 100) / $maxResultCount
+            ## Display the progress
+            if ($ShowProgress) {
+                Write-Progress -Activity "Getting Power BI Audit Log [$($period.StartDate) - $($EndDate)]..." -Status "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" -PercentComplete $percentComplete -ErrorAction SilentlyContinue
+            }
+            "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" | Write-Verbose
+            ## Display the current page results
+            $currentPageResult | Add-Member -MemberType NoteProperty -Name SessionId -Value $sessionID
+            $currentPageResult #| Select-Object CreationDate, UserIds, Operations, AuditData, ResultIndex
+        }
+    }
+    while (
+        ## Continue running while the last ResultIndex in the current page is less than the ResultCount value.
+        ## Note: "ResultIndex" is not ZERO-based.
+        ($currentPageResultCount -lt $maxResultCount) -or ($currentPageResult.Count -gt 0)
+    )
+
+    if ($ShowProgress) {
+        Write-Progress -Activity "Getting Power BI Audit Log [$($period.StartDate) - $($EndDate)]..." -Status "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" -PercentComplete $percentComplete -ErrorAction SilentlyContinue -Completed
     }
 }
-while (
-    ## Continue running while the last ResultIndex in the current page is less than the ResultCount value.
-    ## Note: "ResultIndex" is not ZERO-based.
-        ($currentPageResultCount -lt $maxResultCount) -or ($currentPageResult.Count -gt 0)
-)
 
-if ($ShowProgress) {
-    Write-Progress -Activity "Getting Power BI Audit Log [$($StartDate) - $($EndDate)]..." -Status "Progress: $($currentPageResultCount) of $($maxResultCount) ($([math]::round($percentComplete,2))%)" -PercentComplete $percentComplete -ErrorAction SilentlyContinue -Completed
-}

--- a/Get-PowerBIAuditLog.ps1
+++ b/Get-PowerBIAuditLog.ps1
@@ -65,6 +65,16 @@ param (
     $MaxRetryCount = 3
 )
 
+if ([datetime]($StartDate) -eq [datetime]$EndDate) {
+    "The StartDate and EndDate cannot be the same values." | Write-Verbose
+    return $null
+}
+
+if ([datetime]($EndDate) -le [datetime]($StartDate)) {
+    "The EndDate value cannot be older than the StartDate value." | Write-Verbose
+    return $null
+}
+
 ## Function to Split the search period
 Function Split-Time {
     [cmdletbinding()]
@@ -158,19 +168,10 @@ foreach ($period in $SearchPeriod) {
     $sessionID = (New-Guid).GUID
     $searchCounter++
     "Search # $($searchCounter) of $($searchPeriod.Count)" | Write-Verbose
-    "Start Date: $($period.StartDate)" | Write-Verbose
-    "End Date: $($period.EndDate)" | Write-Verbose
+    # "Start Date: $($period.StartDate)" | Write-Verbose
+    # "End Date: $($period.EndDate)" | Write-Verbose
     "Session Id: $($sessionId)" | Write-Verbose
-
-    if ([datetime]($period.StartDate) -eq [datetime]$period.EndDate) {
-        "The StartDate and EndDate cannot be the same values." | Write-Verbose
-        return $null
-    }
-
-    if ([datetime]($EndDate) -le [datetime]($period.StartDate)) {
-        "The EndDate value cannot be older than the StartDate value." | Write-Verbose
-        return $null
-    }
+    $period | Select-Object StartDate, EndDate | Write-Verbose
 
     Function IsResultProblematic {
         param (

--- a/changes.md
+++ b/changes.md
@@ -1,0 +1,11 @@
+# Changes
+
+## Version 1.1 (2024-04-30)
+
+- Added the `-SplitTimeIntoChunksOf` parameter with the default value of 1.
+  - This parameter indicates the number of chunks to split the duration of the search period.
+  - The purpose is to prevent reaching the maximum search limit of 50,000 of the `Search-UnifiedAuditLog` command.
+
+## Version 1.0
+
+- Initial release.


### PR DESCRIPTION
## Version 1.1 (2024-04-30)

- Added the `-SplitTimeIntoChunksOf` parameter with the default value of 1.
  - This parameter indicates the number of chunks to split the duration of the search period.
  - The purpose is to prevent reaching the maximum search limit of 50,000 of the `Search-UnifiedAuditLog` command.